### PR TITLE
Fix transform syntax in CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -314,7 +314,7 @@ section{
 .project-card:hover{
     background-color: black;
     color: white;
-    transform: translateY(-10px)scale(1.0);
+    transform: translateY(-10px) scale(1.0);
 }
 
 .project-card img{


### PR DESCRIPTION
## Summary
- fix syntax for transform property in hover styles

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841bc66ed24832996272ba1095aa923